### PR TITLE
import React in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { GitHubButtonProps } from 'github-buttons'
 
 export default class GitHubButton extends React.PureComponent<GitHubButtonProps> {}


### PR DESCRIPTION
Fixes:
```bash
ERROR in [at-loader] ./node_modules/react-github-btn/index.d.ts:3:43 
    TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```