### PR TITLE
Ensure node still exists when promise resolves

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ class GitHubButton extends PureComponent {
   paint () {
     const _ = this.$.current.appendChild(document.createElement('span'))
     import(/* webpackMode: "eager" */ 'github-buttons').then(({ render }) => {
+      if (!this._.current) return
       render(_.appendChild(this._.current), function (el) {
         try {
           _.parentNode.replaceChild(el, _)


### PR DESCRIPTION
Hi, thanks for this and `github-buttons`!

I added a simple check for an edge case where the node might not exist by the time the import promise resolves. In my case, the buttons are mounted once a route is signed into, but then there is a potential immediate redirect, in which case React has mounted and unmounted the buttons before the import resolves, by which time `this._.current` is `null`.