### PR TITLE
fix: add missing peer dependency `react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "github-buttons": "^2.21.1"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": ">=16.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "homepage": "https://buttons.github.io/",
   "dependencies": {
     "github-buttons": "^2.21.1"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`react-github-btn` [tries to import `react`](https://github.com/ntkme/react-github-btn/blob/637ebbf67374001bd460e0f94cce8d31e57a6697/index.js#L1) but doesn't declare it as a dependency

**How did you fix it?**

Declared `react` as a peer dependency.